### PR TITLE
Validate format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Mr. Developer
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "openhours"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "openhours"
-    ]
-}

--- a/openhours.go
+++ b/openhours.go
@@ -189,6 +189,9 @@ func new(str string, loc *time.Location) (OpenHours, error) {
 	}
 	for _, str := range strings.Split(cleanStr(str), ";") {
 		strs := strings.Fields(str)
+		if len(strs) < 2 {
+			return nil, ErrInvalidFormat
+		}
 		days := simplifyDays(strs[0])
 		for _, str := range strings.Split(strs[1], ",") {
 			times := strings.Split(str, "-")

--- a/openhours.go
+++ b/openhours.go
@@ -1,13 +1,19 @@
 package openhours
 
 import (
+	"errors"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
 
-var weekDays = map[string]int{"su": 0, "mo": 1, "tu": 2, "we": 3, "th": 4, "fr": 5, "sa": 6}
+var (
+	weekDays = map[string]int{"su": 0, "mo": 1, "tu": 2, "we": 3, "th": 4, "fr": 5, "sa": 6}
+
+	// Errors
+	ErrInvalidFormat error = errors.New("invalid format")
+)
 
 // OpenHours ...
 type OpenHours []time.Time
@@ -170,7 +176,7 @@ func simplifyTime(str string) (int, int, int) {
 	return hour, min, sec
 }
 
-func new(str string, loc *time.Location) OpenHours {
+func new(str string, loc *time.Location) (OpenHours, error) {
 	if loc == nil {
 		loc = time.UTC
 	}
@@ -186,6 +192,9 @@ func new(str string, loc *time.Location) OpenHours {
 		days := simplifyDays(strs[0])
 		for _, str := range strings.Split(strs[1], ",") {
 			times := strings.Split(str, "-")
+			if len(times) != 2 {
+				return nil, ErrInvalidFormat
+			}
 			hourFrom, minFrom, secFrom := simplifyTime(times[0])
 			hourTo, minTo, secTo := simplifyTime(times[1])
 			for _, day := range days {
@@ -193,7 +202,7 @@ func new(str string, loc *time.Location) OpenHours {
 			}
 		}
 	}
-	return o
+	return o, nil
 }
 
 func merge4(o ...time.Time) (bool, []time.Time) {
@@ -229,17 +238,27 @@ func merge(o []time.Time) []time.Time {
 
 // New returns a new instance of an openhours.
 // If loc is nil, UTC is used.
-func New(str string, loc *time.Location) OpenHours {
-	o := new(str, loc)
+func New(str string, loc *time.Location) (OpenHours, error) {
+	o, err := new(str, loc)
+	return merge(o), err
+}
+
+// NewMust returns a new instance of an openhours or panics on error
+// If loc is nil, UTC is used.
+func NewMust(str string, loc *time.Location) OpenHours {
+	o, err := new(str, loc)
+	if err != nil {
+		panic(err)
+	}
 	return merge(o)
 }
 
 // NewLocal returns a new instance of an openhours with local timezone
-func NewLocal(str string) OpenHours {
+func NewLocal(str string) (OpenHours, error) {
 	return New(str, time.Local)
 }
 
 // NewUTC returns a new instance of an openhours with UTC timezone
-func NewUTC(str string) OpenHours {
+func NewUTC(str string) (OpenHours, error) {
 	return New(str, time.UTC)
 }


### PR DESCRIPTION
I had a panic when providing an invalid date format, e.g. `Mo 8:00`. This change catches the invalid time format and returns an error. This is a significant change since it changes the function signature of `New` . I added a `NewMust` which has the same signature as the previous `New` and will panic on error. 

Alternatively, we could add a public `Validate` function that can be called before passing a string to `New`.